### PR TITLE
fix: Fixed a bug, search items are not fond when remove search word r…

### DIFF
--- a/src/containers/sidebar/SidebarContainer.ts
+++ b/src/containers/sidebar/SidebarContainer.ts
@@ -1,5 +1,5 @@
 import { createContainer } from 'unstated-next';
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect, useMemo } from 'react';
 import { toStructualItems } from '../../utils/transformer';
 import { RegStructualItem } from '../../types/reg';
 import { EntityContainer } from '../entity/EntityContainer';
@@ -22,9 +22,9 @@ export const SidebarContainer = createContainer<SidebarValue>(() => {
   const worker = useContext(WorkerContext);
   const entities = EntityContainer.useContainer();
 
-  const defaultNewItems = toStructualItems(entities.newItems);
-  const defaultPassedItems = toStructualItems(entities.passedItems);
-  const defaultFailedItems = toStructualItems(entities.failedItems);
+  const defaultNewItems = useMemo(() => toStructualItems(entities.newItems), [entities.newItems]);
+  const defaultPassedItems = useMemo(() => toStructualItems(entities.passedItems), [entities.passedItems]);
+  const defaultFailedItems = useMemo(() => toStructualItems(entities.failedItems), [entities.failedItems]);
   const defaultDeletedItems = useMemo(() => toStructualItems(entities.deletedItems), [entities.deletedItems]);
 
   const [newItems, setNewItems] = useState(defaultNewItems);

--- a/src/containers/sidebar/SidebarContainer.ts
+++ b/src/containers/sidebar/SidebarContainer.ts
@@ -25,7 +25,7 @@ export const SidebarContainer = createContainer<SidebarValue>(() => {
   const defaultNewItems = toStructualItems(entities.newItems);
   const defaultPassedItems = toStructualItems(entities.passedItems);
   const defaultFailedItems = toStructualItems(entities.failedItems);
-  const defaultDeletedItems = toStructualItems(entities.deletedItems);
+  const defaultDeletedItems = useMemo(() => toStructualItems(entities.deletedItems), [entities.deletedItems]);
 
   const [newItems, setNewItems] = useState(defaultNewItems);
   const [passedItems, setPassedItems] = useState(defaultPassedItems);

--- a/src/containers/sidebar/SidebarContainer.ts
+++ b/src/containers/sidebar/SidebarContainer.ts
@@ -22,10 +22,15 @@ export const SidebarContainer = createContainer<SidebarValue>(() => {
   const worker = useContext(WorkerContext);
   const entities = EntityContainer.useContainer();
 
-  const [newItems, setNewItems] = useState(toStructualItems(entities.newItems));
-  const [passedItems, setPassedItems] = useState(toStructualItems(entities.passedItems));
-  const [failedItems, setFailedItems] = useState(toStructualItems(entities.failedItems));
-  const [deletedItems, setDeletedItems] = useState(toStructualItems(entities.deletedItems));
+  const defaultNewItems = toStructualItems(entities.newItems);
+  const defaultPassedItems = toStructualItems(entities.passedItems);
+  const defaultFailedItems = toStructualItems(entities.failedItems);
+  const defaultDeletedItems = toStructualItems(entities.deletedItems);
+
+  const [newItems, setNewItems] = useState(defaultNewItems);
+  const [passedItems, setPassedItems] = useState(defaultPassedItems);
+  const [failedItems, setFailedItems] = useState(defaultFailedItems);
+  const [deletedItems, setDeletedItems] = useState(defaultDeletedItems);
 
   const [isOpen, setOpen] = useState(true);
   const open = () => setOpen(true);
@@ -37,21 +42,13 @@ export const SidebarContainer = createContainer<SidebarValue>(() => {
     }
 
     const value = input.trim();
-
-    if (value !== '') {
-      worker.requestFilter({
-        input,
-        newItems,
-        passedItems,
-        failedItems,
-        deletedItems,
-      });
-    } else {
-      setNewItems(toStructualItems(entities.newItems));
-      setPassedItems(toStructualItems(entities.passedItems));
-      setFailedItems(toStructualItems(entities.failedItems));
-      setDeletedItems(toStructualItems(entities.deletedItems));
-    }
+    worker.requestFilter({
+      input: value,
+      newItems: defaultNewItems,
+      passedItems: defaultPassedItems,
+      failedItems: defaultFailedItems,
+      deletedItems: defaultDeletedItems,
+    });
   };
 
   useEffect(() => {

--- a/src/worker-main.ts
+++ b/src/worker-main.ts
@@ -37,6 +37,13 @@ const calc = ({
 const filter = ({
   payload: { input, newItems, passedItems, failedItems, deletedItems },
 }: WorkerEventData<WorkerEventType.REQUEST_FILTER>) => {
+  // Return all items when empty input
+  if (!input) {
+    return _self.postMessage({
+      type: WorkerEventType.RESULT_FILTER,
+      payload: { newItems, passedItems, failedItems, deletedItems },
+    });
+  }
   const keys = ['path', 'name'];
   const opts = { caseSensitive: true };
 


### PR DESCRIPTION
@tsuyoshiwada 

Thanks for your great work :)
I ran into searching issue. Please see following gif.

![Peek 2019-08-13 14-05](https://user-images.githubusercontent.com/10220449/62916491-ae357980-bdd3-11e9-9aec-777f756bc15d.gif)

### Reproduced step

1. input search word like `foo`, `aaaaa`.
2. remove all search words rapidly.

### Expected behavior
show all items.

### Actual behavior
all items are not shown.

## Question

Should we filter images in right pane when filter by search word?
Now images in right pane is not changed when searched. Is it expected behavior??