### PR TITLE
fix: Fixed a choice group button style

### DIFF
--- a/src/components/ChoiceGroup/internal/ChoiceButton/ChoiceButton.tsx
+++ b/src/components/ChoiceGroup/internal/ChoiceButton/ChoiceButton.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled(BaseButton)<{ active: boolean }>`
   position: relative;
   display: flex;
   justify-content: center;
+  align-items: center;
   width: 100%;
   height: ${SIZE}px;
   padding: 0 ${Space * 2}px;


### PR DESCRIPTION
I found not centered text in `ChoiceGroup` when using Firefox.

![Screenshot from 2019-08-13 14-48-18](https://user-images.githubusercontent.com/10220449/62918256-16875980-bdda-11e9-91e2-0fd5face04d1.png)
