### PR TITLE
Fix help fab stacking ctx

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -12,6 +12,7 @@ import { IconButton } from '../components/IconButton';
 import { HelpIcon } from '../components/icons/HelpIcon';
 
 const Layout = styled.main`
+  isolation: isolate;
   display: flex;
   height: 100%;
 `;
@@ -53,13 +54,13 @@ export const App: React.FC<Props> = () => (
       </Content>
     </Layout>
 
+    <Viewer />
+    <Notification />
+
     <Help>
       <IconButton variant="black">
         <HelpIcon fill={Color.WHITE} />
       </IconButton>
     </Help>
-
-    <Viewer />
-    <Notification />
   </>
 );

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -11,7 +11,6 @@ const Icon = styled.span`
   position: absolute;
   top: 50%;
   left: ${Space * 2}px;
-  z-index: 1;
   display: block;
   transform: translateY(-50%);
   line-height: 0;
@@ -19,7 +18,6 @@ const Icon = styled.span`
 
 const TextField = styled.input`
   position: relative;
-  z-index: 2;
   display: block;
   width: 100%;
   height: 60px;


### PR DESCRIPTION
I found a styling bug of App component .  Image wrapper is rendered over `<Help />` FAB.

[![Image from Gyazo](https://i.gyazo.com/3f69f3144ec9d43e5b86ecd0361b2e13.png)](https://gyazo.com/3f69f3144ec9d43e5b86ecd0361b2e13)