### PR TITLE
Fix bug that broken when resize container width to small

### DIFF
--- a/src/components/VGrid/VGrid.tsx
+++ b/src/components/VGrid/VGrid.tsx
@@ -213,9 +213,11 @@ export class VGrid<T, K extends keyof T> extends React.Component<Props<T, K>, St
       return media.matches;
     });
     if (!matched) throw new Error('No matched media');
+
     const { gridGap, minContentLength } = matched;
-    const repeatLength = minContentLength ? ~~((containerWidth + gridGap) / (minContentLength + gridGap)) : 1;
+    const repeatLength = (minContentLength && ~~((containerWidth + gridGap) / (minContentLength + gridGap))) || 1;
     const gridStyle = createGridStyleObject(matched);
+
     return { gridStyle, repeatLength, gridGap };
   }
 


### PR DESCRIPTION
## What does this change?

:muscle:

## References

- None

## Screenshots

![resize-bug](https://user-images.githubusercontent.com/5393238/64964283-b2bee780-d8d5-11e9-9b56-a49594e58917.gif)

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
