### PR TITLE
fix: update container state when items change

### DIFF
--- a/src/components/VGrid/VGrid.tsx
+++ b/src/components/VGrid/VGrid.tsx
@@ -173,6 +173,13 @@ export class VGrid<T, K extends keyof T> extends React.Component<Props<T, K>, St
     }
   }
 
+  componentDidUpdate(prevProps: Props<T, K>) {
+    if (!this.containerRef.current) return;
+    if (this.props.items.length !== prevProps.items.length || this.props.cellHeight !== prevProps.cellHeight) {
+      this.updateContainerState(this.containerRef.current.clientWidth);
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener('scroll', this.handleOnScroll);
     window.removeEventListener('hashchange', this.handleOnHashChange);


### PR DESCRIPTION
## What does this change?

A clear and concise description of what the changes is

It fixes a bug that old container height remaining after entity name filtering. This changes force-updates the grid container state(height, grid style, etc...) when the entities of VGrid props changes. 

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
