### PR TITLE
fix: could not load images including '+' in file name on S3

### DIFF
--- a/develop/index.html
+++ b/develop/index.html
@@ -25,8 +25,8 @@
         hasNew: true,
         newItems: [
           { raw: 'sample/sample.png', encoded: 'sample/sample.png' },
-          { raw: 'nest/sample.png?1', encoded: 'nest%2Fsample.png%3F1' },
-          { raw: 'nest/sample.png?2', encoded: 'nest%2Fsample.png%3F2' },
+          { raw: 'nest/sample.png?1', encoded: 'nest%2Fsample.png?1' },
+          { raw: 'nest/sample.png?2', encoded: 'nest%2Fsample.png?2' },
         ],
         hasDeleted: true,
         deletedItems: [
@@ -42,9 +42,9 @@
         failedItems: [
           { raw: 'sample.png?1', encoded: 'sample.png?1' },
           { raw: 'sample.png?2', encoded: 'sample.png?2' },
-          { raw: 'nest/sample.png?3', encoded: 'nest%2Fsample.png%3F3' },
-          { raw: 'nest/sample.png?4', encoded: 'nest%2Fsample.png%3F4' },
-          { raw: 'nest/deep/sample.png?5', encoded: 'nest%2Fdeep%2Fsample.png%3F5' },
+          { raw: 'nest/sample.png?3', encoded: 'nest%2Fsample.png?3' },
+          { raw: 'nest/sample.png?4', encoded: 'nest%2Fsample.png?4' },
+          { raw: 'nest/deep/sample.png?5', encoded: 'nest%2Fdeep%2Fsample.png?5' },
         ],
         actualDir: './actual',
         expectedDir: './expected',

--- a/src/utils/__tests__/transformer.test.ts
+++ b/src/utils/__tests__/transformer.test.ts
@@ -17,9 +17,9 @@ describe('transformer', () => {
         id: `${variant}-${encoded}`,
         variant,
         name: raw,
-        diff: `${dirs.diff}${raw}`,
-        before: `${dirs.expected}${raw}`,
-        after: `${dirs.actual}${raw}`,
+        diff: `${dirs.diff}${encoded}`,
+        before: `${dirs.expected}${encoded}`,
+        after: `${dirs.actual}${encoded}`,
       },
     ]);
   });

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -15,9 +15,9 @@ export const toEntities = (variant: RegVariant, dirs: Dirs, items: RegItem[]): R
       id,
       variant,
       name: item.raw,
-      diff: path.join(dirs.diff, item.raw),
-      before: path.join(dirs.expected, item.raw),
-      after: path.join(dirs.actual, item.raw),
+      diff: path.join(dirs.diff, item.encoded),
+      before: path.join(dirs.expected, item.encoded),
+      after: path.join(dirs.actual, item.encoded),
     };
   });
 


### PR DESCRIPTION
## What does this change?

This changes to use encoded name for image URL.
If image files have '+', we should use '%2B' instead of '+' for URL of these images.
Especially in S3, we cannot access with '+'.
reg-cli-report-ui use raw name for src of image tags.(See References)
So if we upload using `reg-publish-s3-plugin`, the images will not load.

## References

- older version use encoded name for image URL
  - https://github.com/reg-viz/reg-cli/commit/e2a4ce5d1cca69d6abfbb550a8e90a590dd58940#diff-a1e5cfceb1dfa02d663877d2ef1eaa7dL7-L17 (**report/src/views/ItemDetails.vue**)
- in reg-cli-report-ui, raw names are used from initial implementation
  - https://github.com/reg-viz/reg-cli-report-ui/commit/bf8d8d6c9581f198f87fb0d369982eabb654dec6#diff-c7e4f4749c15b57b3e8e9cd841aef5b7R18 (**src/utils/transformer.ts**)

If this difference is intentional, this PR may break something.
I am grad to give me some comments on this.
(I'm afraid I've missed something)

## Screenshots

If image files have '+' in file name, UI keep to show loading icons:
![image](https://user-images.githubusercontent.com/23956/66725641-07bb3280-ee6f-11e9-99a1-d6e70a01eb24.png)

This pull request will fix this to load this image normally:
![image](https://user-images.githubusercontent.com/23956/66725684-7dbf9980-ee6f-11e9-8bae-6808407992dc.png)


## What can I check for bug fixes?

Please use '+' for image file name, then publish using `reg-publish-s3-plugin`.