### PR TITLE
fix: Marker style

### DIFF
--- a/src/components/Viewer/internal/ComparisonView/Markers.tsx
+++ b/src/components/Viewer/internal/ComparisonView/Markers.tsx
@@ -11,6 +11,13 @@ const Wrapper = styled.div`
   z-index: 10;
 `;
 
+const Inner = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  margin: 0 auto;
+`;
+
 const rectStyles = css`
   position: absolute;
   border-width: 1px;
@@ -60,79 +67,83 @@ export const Markers: React.FC<Props> = ({ variant, matching }) => {
 
   return variant === 'before' ? (
     <Wrapper>
-      {matching.matches.map((m, i) => (
-        <React.Fragment key={i}>
-          <Bounding
+      <Inner style={{ maxWidth: w1 }}>
+        {matching.matches.map((m, i) => (
+          <React.Fragment key={i}>
+            <Bounding
+              style={{
+                top: sy1(m[1].bounding),
+                left: sx1(m[1].bounding),
+                width: sw1(m[1].bounding),
+                height: sh1(m[1].bounding),
+              }}
+            />
+            {m[1].diffMarkers.map((r, n) => (
+              <React.Fragment key={n}>
+                <Diff
+                  style={{
+                    top: sy2(r),
+                    left: sx2(r),
+                    width: sw2(r),
+                    height: sh2(r),
+                  }}
+                />
+              </React.Fragment>
+            ))}
+          </React.Fragment>
+        ))}
+        {matching.strayingRects[1].map((r, i) => (
+          <Straying
+            key={i}
             style={{
-              top: sy1(m[1].bounding),
-              left: sx1(m[1].bounding),
-              width: sw1(m[1].bounding),
-              height: sh1(m[1].bounding),
+              top: sy2(r),
+              left: sx2(r),
+              width: sw2(r),
+              height: sh2(r),
             }}
           />
-          {m[1].diffMarkers.map((r, n) => (
-            <React.Fragment key={n}>
-              <Diff
-                style={{
-                  top: sy2(r),
-                  left: sx2(r),
-                  width: sw2(r),
-                  height: sh2(r),
-                }}
-              />
-            </React.Fragment>
-          ))}
-        </React.Fragment>
-      ))}
-      {matching.strayingRects[1].map((r, i) => (
-        <Straying
-          key={i}
-          style={{
-            top: sy2(r),
-            left: sx2(r),
-            width: sw2(r),
-            height: sh2(r),
-          }}
-        />
-      ))}
+        ))}
+      </Inner>
     </Wrapper>
   ) : (
     <Wrapper>
-      {matching.matches.map((m, i) => (
-        <React.Fragment key={i}>
-          <Bounding
+      <Inner style={{ maxWidth: w2 }}>
+        {matching.matches.map((m, i) => (
+          <React.Fragment key={i}>
+            <Bounding
+              style={{
+                top: sy1(m[0].bounding),
+                left: sx1(m[0].bounding),
+                width: sw1(m[0].bounding),
+                height: sh1(m[0].bounding),
+              }}
+            />
+            {m[0].diffMarkers.map((r, n) => (
+              <React.Fragment key={n}>
+                <Diff
+                  style={{
+                    top: sy1(r),
+                    left: sx1(r),
+                    width: sw1(r),
+                    height: sh1(r),
+                  }}
+                />
+              </React.Fragment>
+            ))}
+          </React.Fragment>
+        ))}
+        {matching.strayingRects[0].map((r, i) => (
+          <Straying
+            key={i}
             style={{
-              top: sy1(m[0].bounding),
-              left: sx1(m[0].bounding),
-              width: sw1(m[0].bounding),
-              height: sh1(m[0].bounding),
+              top: sy1(r),
+              left: sx1(r),
+              width: sw1(r),
+              height: sh1(r),
             }}
           />
-          {m[0].diffMarkers.map((r, n) => (
-            <React.Fragment key={n}>
-              <Diff
-                style={{
-                  top: sy1(r),
-                  left: sx1(r),
-                  width: sw1(r),
-                  height: sh1(r),
-                }}
-              />
-            </React.Fragment>
-          ))}
-        </React.Fragment>
-      ))}
-      {matching.strayingRects[0].map((r, i) => (
-        <Straying
-          key={i}
-          style={{
-            top: sy1(r),
-            left: sx1(r),
-            width: sw1(r),
-            height: sh1(r),
-          }}
-        />
-      ))}
+        ))}
+      </Inner>
     </Wrapper>
   );
 };


### PR DESCRIPTION
## What does this change?

I fixed styles of `Markers` component. The rects in marker is rendered at invalid position when `Wrapper` width exceeds the corresponding image width(we can see it via 2up and X-large viewport)

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

### Before 
[![Image from Gyazo](https://i.gyazo.com/c0324c0013e7fc4f5e98d1a0cd53492b.png)](https://gyazo.com/c0324c0013e7fc4f5e98d1a0cd53492b)

### After

[![Image from Gyazo](https://i.gyazo.com/7a43782d3bcf0a29c41135f6ecad68c6.png)](https://gyazo.com/7a43782d3bcf0a29c41135f6ecad68c6)

## What can I check for bug fixes?

- `yarn start`
- Select a diff item
- Choose "2up"