### PR TITLE
Fix broken diff image when use `.jpg`

### DIFF
--- a/src/utils/__tests__/transformer.test.ts
+++ b/src/utils/__tests__/transformer.test.ts
@@ -5,7 +5,7 @@ describe('transformer', () => {
   test('toStructualItems', () => {
     const variant = 'new';
     const raw = 'raw';
-    const encoded = 'encoded';
+    const encoded = 'encoded.jpg';
     const dirs = {
       diff: 'diff/',
       expected: 'expected/',
@@ -17,7 +17,7 @@ describe('transformer', () => {
         id: `${variant}-${encoded}`,
         variant,
         name: raw,
-        diff: `${dirs.diff}${encoded}`,
+        diff: `${dirs.diff}encoded.png`,
         before: `${dirs.expected}${encoded}`,
         after: `${dirs.actual}${encoded}`,
       },

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -15,7 +15,7 @@ export const toEntities = (variant: RegVariant, dirs: Dirs, items: RegItem[]): R
       id,
       variant,
       name: item.raw,
-      diff: path.join(dirs.diff, item.encoded),
+      diff: path.join(dirs.diff, item.encoded).replace(/\.[^.]+$/, '.png'),
       before: path.join(dirs.expected, item.encoded),
       after: path.join(dirs.actual, item.encoded),
     };


### PR DESCRIPTION
## What does this change?

Fixed a bug where the diff items path was inconsistent when using jpg files :pray:

**Expected:**

```diff
- path/to/file.jpg
+ path/to/file.png
```

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
