### PR TITLE
Mutliple line title of item

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -63,7 +63,7 @@ const CardImageInner = styled.span`
 `;
 
 const CardText = styled.div`
-  ${Typography.BODY1};
+  ${Typography.SUBTITLE3};
   padding: ${Space * 2}px;
   text-align: left;
 

--- a/src/components/internal/Ellipsis/Ellipsis.tsx
+++ b/src/components/internal/Ellipsis/Ellipsis.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 export const Ellipsis = styled.span`
-  display: block;
-  overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 `;

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -162,5 +162,5 @@ export enum Depth {
 
 export enum Size {
   HEADER_HEIGHT = 60,
-  CARD_OUTER_HEIGHT = 326,
+  CARD_OUTER_HEIGHT = 360,
 }


### PR DESCRIPTION
## What does this change?

I had a problem when I show long title in items.
In this case, truncated tail of title.
So, I changed below.

- Show 2 lines of title, when overflow truncate tail.
- More bold font of title

## References

None

## Screenshots

| Short pattern | Long pattern |
| -- |  -- |
| ![スクリーンショット 2020-06-12 10 47 26](https://user-images.githubusercontent.com/19924081/84456175-50471c00-ac9a-11ea-9ded-2189b27be4cf.png)  | ![スクリーンショット 2020-06-12 10 48 19](https://user-images.githubusercontent.com/19924081/84456437-eb3ff600-ac9a-11ea-99b3-2a25a18e76d4.png) |


