### PR TITLE
fix: Fix broken image file when using `urlPrefix` flag

### DIFF
--- a/src/utils/__tests__/transformer.test.ts
+++ b/src/utils/__tests__/transformer.test.ts
@@ -6,7 +6,8 @@ describe('transformer', () => {
     const variant = 'new';
     const raw = 'raw';
     const encoded = 'encoded.jpg';
-    const dirs = {
+
+    let dirs = {
       diff: 'diff/',
       expected: 'expected/',
       actual: 'actual/',
@@ -20,6 +21,23 @@ describe('transformer', () => {
         diff: `${dirs.diff}encoded.png`,
         before: `${dirs.expected}${encoded}`,
         after: `${dirs.actual}${encoded}`,
+      },
+    ]);
+
+    dirs = {
+      diff: 'http://localhost:8080/diff',
+      expected: 'http://localhost:8080/expected',
+      actual: 'http://localhost:8080/actual',
+    };
+
+    expect(toEntities(variant, dirs, [{ raw, encoded }])).toEqual([
+      {
+        id: `${variant}-${encoded}`,
+        variant,
+        name: raw,
+        diff: `${dirs.diff}/encoded.png`,
+        before: `${dirs.expected}/${encoded}`,
+        after: `${dirs.actual}/${encoded}`,
       },
     ]);
   });

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { RegItem, RegStructualItem, RegVariant, RegEntity } from '../types/reg';
 
 type Dirs = {
@@ -7,19 +6,22 @@ type Dirs = {
   expected: string;
 };
 
-export const toEntities = (variant: RegVariant, dirs: Dirs, items: RegItem[]): RegEntity[] =>
-  items.map((item) => {
+export const toEntities = (variant: RegVariant, dirs: Dirs, items: RegItem[]): RegEntity[] => {
+  const join = (key: keyof Dirs, to: string) => dirs[key].replace(/\/$/, '') + '/' + to.replace(/^\//, '');
+
+  return items.map((item) => {
     const id = `${variant}-${item.encoded}`;
 
     return {
       id,
       variant,
       name: item.raw,
-      diff: path.join(dirs.diff, item.encoded).replace(/\.[^.]+$/, '.png'),
-      before: path.join(dirs.expected, item.encoded),
-      after: path.join(dirs.actual, item.encoded),
+      diff: join('diff', item.encoded).replace(/\.[^.]+$/, '.png'),
+      before: join('expected', item.encoded),
+      after: join('actual', item.encoded),
     };
   });
+};
 
 export const toStructualItems = (entities: RegEntity[]): RegStructualItem[] => {
   const results: RegStructualItem[] = [];


### PR DESCRIPTION
## What does this change?

Fixed a bug in URL merging with the `path` module.

```diff
- http:/localhost:8080/path/to.png  # actual
+ http://localhost:8080/path/to.png # expect
```

## References

- Nothing.

## Screenshots

- Nothing.

<!-- If applicable, add screenshots to help explain your changes. -->

## What can I check for bug fixes?

- Specify a URL that includes the protocol in the directory name and make it work.