### PR TITLE
Switch to preact from react

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fuzzy-search": "^3.2.1",
     "keycode": "^2.2.0",
     "mousetrap": "^1.6.5",
+    "preact": "^10.5.10",
     "rc-slider": "^9.7.1",
     "re-resizable": "^6.9.0",
     "react": "17.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,11 @@ const common = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
     modules: [SRC_PATH, 'node_modules'],
+    alias: {
+      react: 'preact/compat',
+      'react-dom/test-utils': 'preact/test-utils',
+      'react-dom': 'preact/compat',
+    },
   },
 
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9763,6 +9763,11 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact@^10.5.10:
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.10.tgz#8de7bf669e965a51fc9e45a6fd1e97a47af383e6"
+  integrity sha512-A6SITnHaj5CS4JPLVroQDNOEozq4Y0B4yQSGHLznxHe66Jb2DvoeTEibLjXmfeofgQE3BZ2zurltBIapzCMlwg==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"


### PR DESCRIPTION
## What does this change?

Reduce the bundle size by about 25%. (432.827 KB -> 328.751 KB)

## References

- [Getting Started | Preact: Fast 3kb React alternative with the same ES6 API. Components & Virtual DOM.](https://preactjs.com/guide/v10/getting-started/#aliasing-in-webpack)

## Screenshots

n/a

## What can I check for bug fixes?

n/a
