### PR TITLE
Fix a mix-up between before and after images in the slide view

### DIFF
--- a/src/components/Viewer/internal/ComparisonView/Slide.tsx
+++ b/src/components/Viewer/internal/ComparisonView/Slide.tsx
@@ -48,11 +48,11 @@ const View = styled.div`
 
 const Before = styled(View)`
   z-index: 0;
-  transform: translate(0, 0);
 `;
 
 const After = styled(View)`
   z-index: 1;
+  transform: translate(0, 0);
 `;
 
 const Handle = styled.span`
@@ -182,37 +182,37 @@ export const Slide: React.FC<Props> = ({
           onChange={handleChange}
         />
 
-        <Frame style={{ width: `${value}%` }}>
-          <Before
-            style={{
-              top: 0,
-              left: canvas.width / 2 - image.before.width / 2,
-              width: image.before.width,
-              height: image.before.height,
-            }}
-          >
-            <Image
-              ref={image.before.ref}
-              src={before}
-              onLoad={image.before.handleLoad}
-            />
-            <Markers variant="before" matching={matching} />
-          </Before>
-        </Frame>
-
-        <After
+        <Before
           style={{
-            width: image.after.width,
-            height: image.after.height,
+            width: image.before.width,
+            height: image.before.height,
           }}
         >
           <Image
-            ref={image.after.ref}
-            src={after}
-            onLoad={image.after.handleLoad}
+            ref={image.before.ref}
+            src={before}
+            onLoad={image.before.handleLoad}
           />
-          <Markers variant="after" matching={matching} />
-        </After>
+          <Markers variant="before" matching={matching} />
+        </Before>
+
+        <Frame style={{ width: `${value}%` }}>
+          <After
+            style={{
+              top: 0,
+              left: canvas.width / 2 - image.after.width / 2,
+              width: image.after.width,
+              height: image.after.height,
+            }}
+          >
+            <Image
+              ref={image.after.ref}
+              src={after}
+              onLoad={image.after.handleLoad}
+            />
+            <Markers variant="after" matching={matching} />
+          </After>
+        </Frame>
 
         <Handle style={{ left: `${value}%` }}>
           <HandleBar />


### PR DESCRIPTION
## What does this change?

The before and after images in the slider view were misplaced. The correct behavior should be to show the after image when the slider is moved to the right edge, so they have been corrected.

## Screenshots

### Before fix

<img src="https://user-images.githubusercontent.com/13102129/141675485-dda75f3d-2be6-4de7-94bb-a10394fbab5b.png" width="500" />

### After fix

<img src="https://user-images.githubusercontent.com/13102129/141675505-fc9464a7-b488-4bc9-9b49-2a8cc0ca0b2f.png" width="500" />
