### PR TITLE
fix: ignore error when failed to instantiate worker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,12 @@ const regData = (window as any)['__reg__'] as RegData;
 const workerClient = new WorkerClient();
 const ximgdiffConfig = regData.ximgdiffConfig || { enabled: false };
 
+// INFO: set false on file: protocol
+// ref: https://github.com/reg-viz/reg-cli/issues/506
+if (window.location.protocol.startsWith('file')) {
+  ximgdiffConfig.enabled = false;
+}
+
 workerClient.start(ximgdiffConfig);
 
 // Store

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -53,9 +53,14 @@ export class WorkerClient {
     }
 
     this._ximgdiffEnabled = config.enabled;
-    this._worker = new Worker(config.workerUrl, {});
+    try {
+      this._worker = new Worker(config.workerUrl, {});
+    } catch (reason) {
+      // NOP: ignore error if failed to instantiate worker.
+      // ref: https://github.com/reg-viz/reg-cli/issues/506
+    }
 
-    this._worker.addEventListener('message', ({ data }: WorkerEvent) => {
+    this._worker?.addEventListener('message', ({ data }: WorkerEvent) => {
       switch (data.type) {
         case WorkerEventType.RESULT_CALC:
           this._cache[data.payload.raw] = data.payload;


### PR DESCRIPTION
## What does this change?

ignore worker instantiate error. ref: https://github.com/reg-viz/reg-cli/issues/506
I think it is better to continue rendering report if failed to instantiate worker.

## References

https://github.com/reg-viz/reg-cli/issues/506

## Screenshots

NA

## What can I check for bug fixes?

NA
