### PR TITLE
feat: support rendering of 'flake mark', that can be used to indicate how frequently a 'changed item' (image) has recently flaked

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -36,6 +36,17 @@ export const WithLongName: Story = {
   },
 };
 
+export const WithFlakeMark: Story = {
+  args: {
+    entity: {
+      ...defaultEntity,
+      modificationCount: 9,
+      totalCommitCount: 27,
+      periodInDays: 10,
+    },
+  },
+};
+
 export const WithNew: Story = {
   args: {
     entity: {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -65,6 +65,11 @@ export const Card = ({ href, entity, menus, onCopy }: Props) => {
     [entity.id, onCopy],
   );
 
+  const showFlakeMark =
+    entity.modificationCount &&
+    entity.modificationCount > 1 &&
+    entity.modificationCount / (entity.totalCommitCount || 1) >= 0.1;
+
   return (
     <div id={entity.id} className={styles.wrapper}>
       <BaseButton
@@ -74,6 +79,17 @@ export const Card = ({ href, entity, menus, onCopy }: Props) => {
       >
         <div className={styles.sign}>
           <Sign variant={entity.variant} />
+          {showFlakeMark && (
+            <span>
+              {Math.round(
+                ((entity.modificationCount || 1) * 100) /
+                  (entity.totalCommitCount || 1),
+              )}
+              % flaky
+              {entity.periodInDays &&
+                ` over the past ${entity.periodInDays} days(0).`}
+            </span>
+          )}
         </div>
 
         <div className={styles.image}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,6 +9,7 @@ import { BaseButton } from '../internal/BaseButton';
 import { Ellipsis } from '../internal/Ellipsis';
 import { Transparent } from '../internal/Transparent';
 import { Color } from '../../styles/variables.css';
+import { FlakeMark } from '../FlakeMark';
 import * as styles from './Card.css';
 
 const imageSrc = (entity: RegEntity) => {
@@ -65,11 +66,6 @@ export const Card = ({ href, entity, menus, onCopy }: Props) => {
     [entity.id, onCopy],
   );
 
-  const showFlakeMark =
-    entity.modificationCount &&
-    entity.modificationCount > 1 &&
-    entity.modificationCount / (entity.totalCommitCount || 1) >= 0.1;
-
   return (
     <div id={entity.id} className={styles.wrapper}>
       <BaseButton
@@ -79,17 +75,7 @@ export const Card = ({ href, entity, menus, onCopy }: Props) => {
       >
         <div className={styles.sign}>
           <Sign variant={entity.variant} />
-          {showFlakeMark && (
-            <span>
-              {Math.round(
-                ((entity.modificationCount || 1) * 100) /
-                  (entity.totalCommitCount || 1),
-              )}
-              % flaky
-              {entity.periodInDays &&
-                ` over the past ${entity.periodInDays} days(0).`}
-            </span>
-          )}
+          <FlakeMark {...entity} />
         </div>
 
         <div className={styles.image}>

--- a/src/components/FlakeMark.tsx
+++ b/src/components/FlakeMark.tsx
@@ -7,10 +7,7 @@ export const FlakeMark: FC<FlakeData> = ({
   totalCommitCount,
   periodInDays,
 }) => {
-  const showFlakeMark =
-    modificationCount &&
-    modificationCount > 1 &&
-    modificationCount / (totalCommitCount || 1) >= 0.1;
+  const showFlakeMark = modificationCount !== undefined && modificationCount > 0;
 
   if (!showFlakeMark) {
     return null;

--- a/src/components/FlakeMark.tsx
+++ b/src/components/FlakeMark.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { FC } from 'react';
+import type { FlakeData } from '../types/reg';
+
+export const FlakeMark: FC<FlakeData> = ({
+  modificationCount,
+  totalCommitCount,
+  periodInDays,
+}) => {
+  const showFlakeMark =
+    modificationCount &&
+    modificationCount > 1 &&
+    modificationCount / (totalCommitCount || 1) >= 0.1;
+
+  if (!showFlakeMark) {
+    return null;
+  }
+
+  return (
+    <span style={{ margin: '0 16px' }}>
+      <strong>
+        {Math.round(((modificationCount || 1) * 100) / (totalCommitCount || 1))}
+        % flaky
+      </strong>
+      {periodInDays && ` over the past ${periodInDays} day(s)`}
+    </span>
+  );
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { useMedia } from '../../hooks/useMedia';
 import type { RegVariant } from '../../types/reg';
 import { IconButton } from '../IconButton';
@@ -19,7 +20,7 @@ export type Props = {
   onMarkersToggle: () => void;
 };
 
-export const Header = ({
+export const Header: FC<PropsWithChildren<Props>> = ({
   variant,
   title,
   current,
@@ -27,7 +28,8 @@ export const Header = ({
   markersEnabled,
   onRequestClose,
   onMarkersToggle,
-}: Props) => {
+  children,
+}) => {
   const isSmallViewport = useMedia(`(max-width: ${BreakPoint.SMALL - 1}px)`);
 
   const handleCloseClick = useCallback(
@@ -72,6 +74,8 @@ export const Header = ({
             onChange={handleToggle}
           />
         </div>
+
+        {children}
       </div>
     </header>
   );

--- a/src/components/Viewer/Viewer.stories.tsx
+++ b/src/components/Viewer/Viewer.stories.tsx
@@ -61,6 +61,17 @@ export const Overview: Story = {
 
 export const WithChanged: Story = {};
 
+export const WithFlakeMark: Story = {
+  args: {
+    entity: {
+      ...defaultEntity,
+      modificationCount: 9,
+      totalCommitCount: 27,
+      periodInDays: 10,
+    },
+  },
+};
+
 export const WithNew: Story = {
   args: {
     entity: {

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -13,6 +13,7 @@ import { ArrowRightIcon } from '../icons/ArrowRightIcon';
 import { Portal } from '../internal/Portal';
 import { Transparent } from '../internal/Transparent';
 import { usePrevious } from '../../hooks/usePrevious';
+import { FlakeMark } from '../FlakeMark';
 import * as styles from './Viewer.css';
 import { OPEN_DELAY } from './constants';
 import { ComparisonView } from './internal/ComparisonView';
@@ -160,7 +161,9 @@ export const Viewer = ({
                   markersEnabled={markersEnabled}
                   onRequestClose={onRequestClose}
                   onMarkersToggle={onMarkersToggle}
-                />
+                >
+                  <FlakeMark {...displayEntity} />
+                </Header>
               )}
             </div>
 

--- a/src/types/reg.ts
+++ b/src/types/reg.ts
@@ -5,10 +5,16 @@ export type XIMGDiffConfig = {
   workerUrl?: string;
 };
 
+type FlakeData = {
+  modificationCount?: number;
+  totalCommitCount?: number;
+  periodInDays?: number;
+};
+
 export type RegItem = {
   raw: string;
   encoded: string;
-};
+} & FlakeData;
 
 export type RegLink = {
   href: string;
@@ -40,7 +46,7 @@ export type RegEntity = {
   diff: string;
   before: string;
   after: string;
-};
+} & FlakeData;
 
 export type RegStructualItem = {
   id: string;

--- a/src/types/reg.ts
+++ b/src/types/reg.ts
@@ -5,7 +5,7 @@ export type XIMGDiffConfig = {
   workerUrl?: string;
 };
 
-type FlakeData = {
+export type FlakeData = {
   modificationCount?: number;
   totalCommitCount?: number;
   periodInDays?: number;

--- a/src/utils/__tests__/transformer.test.ts
+++ b/src/utils/__tests__/transformer.test.ts
@@ -7,6 +7,9 @@ describe('transformer', () => {
     const variant = 'new';
     const raw = 'raw';
     const encoded = 'encoded.jpg';
+    const modificationCount = 9;
+    const totalCommitCount = 30;
+    const periodInDays = 10;
 
     let dirs = {
       diff: 'diff/',
@@ -14,7 +17,11 @@ describe('transformer', () => {
       actual: 'actual/',
     };
 
-    expect(toEntities(variant, dirs, [{ raw, encoded }])).toEqual([
+    expect(
+      toEntities(variant, dirs, [
+        { raw, encoded, modificationCount, totalCommitCount },
+      ]),
+    ).toEqual([
       {
         id: `${variant}-${encoded}`,
         variant,
@@ -22,6 +29,9 @@ describe('transformer', () => {
         diff: `${dirs.diff}encoded.png`,
         before: `${dirs.expected}${encoded}`,
         after: `${dirs.actual}${encoded}`,
+        modificationCount,
+        totalCommitCount,
+        periodInDays,
       },
     ]);
 

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -22,6 +22,7 @@ export const toEntities = (
 
   return items.map((item) => {
     const id = `${variant}-${item.encoded}`.replace(/[=?]/g, '-');
+    const { modificationCount, totalCommitCount, periodInDays } = item;
 
     return {
       id,
@@ -30,6 +31,9 @@ export const toEntities = (
       diff: join('diff', item.encoded).replace(/\.[^.]+$/, `.${diffExtension}`),
       before: join('expected', item.encoded),
       after: join('actual', item.encoded),
+      modificationCount,
+      totalCommitCount,
+      periodInDays,
     };
   });
 };


### PR DESCRIPTION
## What does this change?

feat: support rendering of 'flake mark', that can be used to indicate how frequently a 'changed item' (image) has recently flaked

## References

This is an feature that'll be conditionally (based on modificationCount, totalCommitCount, & periodInDays props) rendering the 'flake mark' text on top of Card & Viewer components.

## Screenshots

Card: <img width="1113" alt="image" src="https://github.com/user-attachments/assets/4a44348d-60a8-448c-af60-21b7fdb65f34" />

Viewer: <img width="1526" alt="image" src="https://github.com/user-attachments/assets/c8168742-6531-4601-b4c7-d052d77f84db" />


## What can I check for bug fixes?

N/A, not a bug
